### PR TITLE
Time zone guessing improved, fixes 'Assuming time zone Etc/GMT for Etc/G...

### DIFF
--- a/app/src/main/java/at/bitfire/davdroid/resource/Event.java
+++ b/app/src/main/java/at/bitfire/davdroid/resource/Event.java
@@ -341,25 +341,38 @@ public class Event extends Resource {
 
 	/* guess matching Android timezone ID */
 	protected static void validateTimeZone(DateProperty date) {
-		if (date.isUtc() || !hasTime(date))
-			return;
-		
-		String tzID = getTzId(date);
-		if (tzID == null)
-			return;
-		
-		String localTZ = Time.TIMEZONE_UTC;
-		
-		String availableTZs[] = SimpleTimeZone.getAvailableIDs();
-		for (String availableTZ : availableTZs)
-			if (tzID.indexOf(availableTZ, 0) != -1) {
-				localTZ = availableTZ;
-				break;
-			}
-		
-		Log.d(TAG, "Assuming time zone " + localTZ + " for " + tzID);
-		date.setTimeZone(tzRegistry.getTimeZone(localTZ));
-	}
+        if (date.isUtc() || !hasTime(date))
+            return;
+
+        String tzID = getTzId(date);
+        if (tzID == null)
+            return;
+
+        String localTZ = Time.TIMEZONE_UTC;
+        boolean foundMatch = false;
+        String availableTZs[] = SimpleTimeZone.getAvailableIDs();
+
+        // Try to find an exact match
+        for (String availableTZ : availableTZs) {
+            if (tzID.equals(availableTZ)) {
+                localTZ = availableTZ;
+                foundMatch = true;
+                break;
+            }
+        }
+
+        if (!foundMatch) {
+            // Try to find something else that matches
+            for (String availableTZ : availableTZs) {
+                if (tzID.indexOf(availableTZ, 0) != -1) {
+                    localTZ = availableTZ;
+                    break;
+                }
+            }
+        }
+        Log.d(TAG, "Assuming time zone " + localTZ + " for " + tzID);
+        date.setTimeZone(tzRegistry.getTimeZone(localTZ));
+    }
 
 	public static String TimezoneDefToTzId(String timezoneDef) throws IllegalArgumentException {
 		try {


### PR DESCRIPTION
...MT-2'

Hi, while playing with the source I saw a strange message in the log: 'Assuming time zone Etc/GMT for Etc/GMT-2'. That couldn't be right, so I found validateTimeZone in Event.java to be the cause of this. The current version just checks if one of the available timezones name matches the start of the event's timezone name, making Etc/GMT match Etc/GMT-2, which is incorrect. My change first looks for an exact match if that fails it executes the old procedure.

Let me know what you think, I'm happy to tune the code if neccesary.